### PR TITLE
Fix case-insensitive searching.

### DIFF
--- a/init/options.vim
+++ b/init/options.vim
@@ -50,7 +50,8 @@ set laststatus=2                " Always show statusline
 
 set incsearch                   " Incremental search
 set history=1024                " History size
-set smartcase                   " Smart case-sensitivity when searching (overrides ignorecase)
+set ignorecase                  " Case-insensitive search...
+set smartcase                   " ...unless a capitalized character is entered
 
 set autoread                    " No prompt for file changes outside Vim
 


### PR DESCRIPTION
Smartcase doesn't work as expected unless ignorecase is also set.

http://vim.wikia.com/wiki/Searching#Case_sensitivity
