### PR TITLE
Remove "e" abbreviation for edit-plus, as it breaks "e!".

### DIFF
--- a/after/plugin/edit_plus.vim
+++ b/after/plugin/edit_plus.vim
@@ -1,0 +1,2 @@
+" Disable override of standard "e" command
+una e


### PR DESCRIPTION
What it says on the tin.

I know that "you shouldn't have to ever refresh the file, because we've `set autoread`" but sometimes it doesn't actually refresh. Unfortunately, the edit-plus command won't let you enter `e!`, and `EP!` doesn't work either.

I've left the edit-plus plugin in place. To access it after this commit, you have to literally type `EP whatever`.

This plugin breaks core vim functionality to provide an alias to `e +3 filename.txt` or `e filename.txt | 3`, neither of which is really much harder than `EP filename.txt:3`. Reasonable people may disagree.
