### PR TITLE
Remove EnhancedJumps plugin

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -89,7 +89,6 @@ Bundle 'burke/matcher'
 " Navigation
 "
 Bundle 'scrooloose/nerdtree'
-Bundle 'EnhancedJumps'
 Bundle 'majutsushi/tagbar'
 
 "


### PR DESCRIPTION
This plugin takes extra key presses when jumping between buffers.
It also throws warnings when it does actually switch the buffer
