### PR TITLE
Ensure graceful handling of UTF-8 characters

### DIFF
--- a/init/options.vim
+++ b/init/options.vim
@@ -1,3 +1,5 @@
+scriptencoding utf-8
+
 set guifont=Menlo:h14
 set guioptions-=T               " Remove GUI toolbar
 set guioptions-=e               " Use text tab bar, not GUI


### PR DESCRIPTION
Forcing the encoding to UTF-8 ensures that vim, when started in a non-UTF-8 environment, can gracefully handle the presence of UTF-8 characters in the file. Instead of generating errors, extended characters will be transliterated.

http://superuser.com/questions/556915/how-to-let-vim-listchar-work-under-not-utf8-environment

This further supports #27.
