### PR TITLE
Remove quick binding for Ggrep, which conflicts with existing Gblame.

### DIFF
--- a/init/keybindings.vim
+++ b/init/keybindings.vim
@@ -126,9 +126,6 @@ map <leader>a :call AckGrep()<CR>
 " AckVisual current selection
 vmap <leader>a :call AckVisual()<CR>
 
-" Quick git grep
-map <leader>gg :Ggrep ""<Left>
-
 " Recalculate diff when it gets messed up.
 nmap du :diffupdate<CR>
 


### PR DESCRIPTION
Previously, ",g" would show the git blame drawer. Now ",g" does nothing,
because it's waiting for you to finish typing "gg" for Ggrep. This
reverts to the earlier behavior.
