### PR TITLE
Remove duplicate ruby snippets

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -1,4 +1,0 @@
-snippet let
-	let(:${1}) { ${2} }
-snippet its
-	its(:${1}) { ${2} }


### PR DESCRIPTION
The snippets/ruby.snippets file defines two snippets
that already exist in the vim bundle.  When you try
to use either `let` or `its`, vim must ask you which
of the identical snippets you wish to use.

Removing the duplicates means that your snippets are
actually faster than typing the expanded text out
manually.
