### PR TITLE
Add vim-simple-bdd for generating simple_bdd methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ lets you view and cycle through your previous copy and paste registers on the fl
 * [ConqueTerm](http://code.google.com/p/conque/) lets your run interactive commands within vim.  Try `:ConqueTerm bash`.
 * [vitality.vim](https://github.com/sjl/vitality.vim) makes Vim play nicely with iTerm2 and tmux. It adds things like cursor change on insert mode and focus-lost detection for triggering auto-save.
 * [test_server](https://github.com/brysgo/test_server) lets you use F9 thru F12 to run specs and report the output in vim.
+* [vim-simple-bdd](https://github.com/mdelillo/vim-simple-bdd) generates method declarations from [simple_bdd](https://github.com/robb1e/simple_bdd) steps
 
 ## Colorschemes
 * [Vivid Chalk](https://github.com/tpope/vim-vividchalk)

--- a/init/keybindings.vim
+++ b/init/keybindings.vim
@@ -186,3 +186,7 @@ map <D-F> :Ag<Space>
 
 " Convert a word to to let(:word) { double(:word) }
 nmap <leader>ld <Plug>LocalMakelet
+
+" Convert simple_bdd steps into methods
+nnoremap <leader>bdd :SimpleBDD<CR>
+vnoremap <leader>bdd :SimpleBDD<CR>

--- a/vimrc
+++ b/vimrc
@@ -140,6 +140,7 @@ Plugin 'tpope/vim-dispatch'
 Plugin 'carlobaldassi/ConqueTerm'
 Plugin 'sjl/vitality.vim'
 Plugin 'brysgo/test_server'
+Plugin 'mdelillo/vim-simple-bdd'
 
 call vundle#end()
 filetype plugin indent on


### PR DESCRIPTION
vim-simple-bdd makes it easier to write specs using simple_bdd.

It turns a line like this:
``` ruby
Given 'This is some setup'
```

Into this:
```ruby
def this_is_some_setup
  |
end
```
Where `|` is your cursor.

It can also convert multiple lines given a range or using visual mode.