### PR TITLE
treat .es6 files as JavaScript

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -165,4 +165,5 @@ if filereadable($HOME . "/.vimrc.local")
 endif
 
 au BufRead,BufNewFile *.hamlc set ft=haml
+au BufRead,BufNewFile *.es6 set ft=javascript
 


### PR DESCRIPTION
Use JS syntax highlighting for .es6 files, like the [sprockets-es6](https://github.com/TannerRogalsky/sprockets-es6) gem requires.